### PR TITLE
Fix logging description output

### DIFF
--- a/backend/core/src/main.cpp
+++ b/backend/core/src/main.cpp
@@ -38,7 +38,7 @@ void printLoadedModules(logging::ConsoleLogger& logger, Core& core)
             {
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t{");
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay name: " << module_info->publish_producers_[j].display_name_);
-                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->publish_producers_[j].display_name_);
+                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->publish_producers_[j].display_description_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tChannel type identifier: " << module_info->publish_producers_[j].channel_type_identifier_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t}");
             }
@@ -56,7 +56,7 @@ void printLoadedModules(logging::ConsoleLogger& logger, Core& core)
             {
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t{");
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay name: " << module_info->response_producers_[j].display_name_);
-                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->response_producers_[j].display_name_);
+                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->response_producers_[j].display_description_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tChannel type identifier: " << module_info->response_producers_[j].channel_type_identifier_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t}");
             }
@@ -74,7 +74,7 @@ void printLoadedModules(logging::ConsoleLogger& logger, Core& core)
             {
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t{");
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay name: " << module_info->subscribe_consumers_[j].display_name_);
-                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->subscribe_consumers_[j].display_name_);
+                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->subscribe_consumers_[j].display_description_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tChannel type identifier: " << module_info->subscribe_consumers_[j].channel_type_identifier_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tCount: " << (int)module_info->subscribe_consumers_[j].count_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tMin: " << (int)module_info->subscribe_consumers_[j].min_);
@@ -95,7 +95,7 @@ void printLoadedModules(logging::ConsoleLogger& logger, Core& core)
             {
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t{");
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay name: " << module_info->request_consumers_[j].display_name_);
-                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->request_consumers_[j].display_name_);
+                log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tDisplay description: " << module_info->request_consumers_[j].display_description_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tChannel type identifier: " << module_info->request_consumers_[j].channel_type_identifier_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tCount: " << (int)module_info->request_consumers_[j].count_);
                 log(logger, aergo::module::logging::LogType::INFO, std::stringstream() << "\t\t\t\t\tMin: " << (int)module_info->request_consumers_[j].min_);


### PR DESCRIPTION
## Summary
- fix module logging to use display_description instead of display_name

## Testing
- `cd backend/core && rm -rf build && mkdir build && cd build && cmake -DBUILD_TESTING=OFF .. && cmake --build . && ctest` *(fails: Catch2Config.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af26f90ba483288b9e62748b6e310a