### PR TITLE
Fix typo in ParameterList cached string member

### DIFF
--- a/backend/module_helpers/activation_wrapper/include/module_helpers/activation_wrapper/parameter_description.h
+++ b/backend/module_helpers/activation_wrapper/include/module_helpers/activation_wrapper/parameter_description.h
@@ -68,6 +68,6 @@ namespace aergo::module::helpers::activation_wrapper::params
 
     private:
         std::vector<ParameterDescription> parameters_;
-        std::string cashed_string_;
+        std::string cached_string_;
     };
 }

--- a/backend/module_helpers/activation_wrapper/src/parameter_description.cpp
+++ b/backend/module_helpers/activation_wrapper/src/parameter_description.cpp
@@ -95,7 +95,7 @@ ParameterList::ParameterList(std::vector<ParameterDescription>&& parameters)
 
 std::string ParameterList::toString()
 {
-    if (cashed_string_.empty())
+    if (cached_string_.empty())
     {
         std::stringstream stream;
         stream.precision(std::numeric_limits<double>::max_digits10);
@@ -108,10 +108,10 @@ std::string ParameterList::toString()
             param.toStringStream(stream);
         }
 
-        cashed_string_ = stream.str();
+        cached_string_ = stream.str();
     }
 
-    return cashed_string_;
+    return cached_string_;
 }
 
 


### PR DESCRIPTION
## Summary
- rename `cashed_string_` to `cached_string_` in `ParameterList`
- update activation wrapper parameter serialization to use the new name

## Testing
- `cmake -S . -B build` *(fails: could not find vcpkg or OpenCV)*
- `ctest --test-dir build` *(fails: No tests were found)*
- `g++ -std=c++23 -include limits -Ibackend/module_helpers/activation_wrapper/include backend/module_helpers/activation_wrapper/src/parameter_description.cpp -c`


------
https://chatgpt.com/codex/tasks/task_e_68af291fe3e08328b528ca69ea545380