### PR TITLE
Fix module load error logging

### DIFF
--- a/backend/core/lib/core/src/core.cpp
+++ b/backend/core/lib/core/src/core.cpp
@@ -108,6 +108,7 @@ void Core::loadModules(const char* modules_dir, const char* data_dir)
                     break;
                 case ModuleLoadError::FAILED_TO_MAP_METHODS:
                     log_message += "(FAILED_TO_MAP_METHODS): " + module_filename;
+                    break;
                 default:
                     log_message += "(UNKNOWN): " + module_filename;
             }


### PR DESCRIPTION
## Summary
- avoid misleading log messages when module load error is `FAILED_TO_MAP_METHODS`

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: C:/lib/vcpkg/scripts/buildsystems/vcpkg.cmake; could not find OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d37a0048328acfbe532fbf23bec